### PR TITLE
Widget Feature

### DIFF
--- a/(get)Homepage Widget.txt
+++ b/(get)Homepage Widget.txt
@@ -1,0 +1,25 @@
+- An API endpoint exists for a custom api widget for Homepage. Use the below in services.yaml
+
+    - newznabarr:
+        icon: https://media.licdn.com/dms/image/v2/D5612AQGgaUhfRZ8MMQ/article-cover_image-shrink_720_1280/article-cover_image-shrink_720_1280/0/1682975314473?e=2147483647&v=beta&t=Vzhm0a1oTdYBR4H_ulMpVcq0yiLolHRC6YiB8c2_knY # Placeholder
+        href: http://<IP>:10000/queue # Can use subdomain if behind reverse proxy
+        #target: _self
+        ping: http://newznabarr:10000 # Docker internal address if on the same docker network. Or use your IP and port
+        statusStyle: "dot"
+        description: download plugin
+        widget:
+            type: customapi
+            url: http://newznabarr:10000/api?mode=widget&apikey=<API_KEY>> # Docker internal address if on the same docker network. Or use your IP and port
+            refreshInterval: 10000 # Refresh every 10 seconds
+            method: GET
+            display: block
+            mappings:
+                - field: downloading
+                  label: Downloading
+                  format: number
+                - field: queued
+                  label: Queued
+                  format: number
+                - field: failed
+                  label: Failed
+                  format: number

--- a/app.py
+++ b/app.py
@@ -9,6 +9,7 @@ import string
 import hashlib
 import threading
 import time
+import json
 
 from plugin_search_interface import PluginSearchBase
 from plugin_download_interface import PluginDownloadBase
@@ -22,9 +23,9 @@ FLASK_PORT = os.environ.get("FLASK_RUN_PORT", "10000")
 FLASK_HOST = os.environ.get("FLASK_RUN_HOST", "0.0.0.0")
 PLUGIN_SEARCH_DIR = os.path.join(CONFIG_DIR, "plugins","search")
 PLUGIN_DOWNLOAD_DIR = os.path.join(CONFIG_DIR, "plugins","download")
-DOWNLOAD_DIR = "/data/downloads/downloadarr"
-SAB_API = "abcde"
-SAB_CATEGORIES = ["lidarr"]
+DOWNLOAD_DIR = "/data/usenet/complete"
+SAB_API = None
+SAB_CATEGORIES = ["books","music","audiobooks"]
 
 # array holding plugins
 search_plugins = []
@@ -36,6 +37,7 @@ app = Flask(__name__)
 
 # load all the search plugins
 def load_search_plugins(search_plugin_directory):
+    global search_plugins
     search_plugins = []
     sys.path.insert(0, search_plugin_directory)
     print("Loading search plugins from:" + search_plugin_directory)
@@ -56,7 +58,8 @@ def load_search_plugins(search_plugin_directory):
     return search_plugins
 
 def load_download_plugins(download_plugin_directory):
-    download_plugins = []    
+    global download_plugins
+    download_plugins = []
     sys.path.insert(0, download_plugin_directory)
     print("Loading download plugins from:" + download_plugin_directory)
 
@@ -118,11 +121,17 @@ def start():
         DOWNLOAD_DIR = config.get("download_directory", DOWNLOAD_DIR)
         SAB_API = config.get("sab_api", SAB_API)
         SAB_CATEGORIES = config.get("sab_categories", SAB_CATEGORIES)
+        
+        # Validate if SAB_API is still set to the default 'abcde'
+        if SAB_API == 'abcde':
+            print("Warning: API key is set to the default value 'abcde'. Please update your configuration.")
+        elif SAB_API == '':
+            print("Warning: API key value is empty. Please update your configuration.")
+            
     #load search plugins
     global search_plugins
     global download_plugins
     global sabqueue
-    print("Going to load search plugins")
     print("Going to load search plugins")
     search_plugins = load_search_plugins(PLUGIN_SEARCH_DIR)
     download_plugins = load_download_plugins(PLUGIN_DOWNLOAD_DIR)
@@ -361,13 +370,49 @@ def api():
             else:
                 return sabgethistory(sabqueue)
         return jsonify({"error": "Access Denied"}), 403
+        
+    elif request.args.get("mode") == 'widget':
+        if SAB_API == request.args.get("apikey"):
+            # Check if sabqueue is empty and return default counts
+            if not sabqueue:  # If queue is empty
+                return jsonify({
+                    "downloading": 0,
+                    "queued": 0,
+                    "failed": 0
+                })
+
+            # Initialize counts for downloading, queued, and failed
+            downloading_count = 0
+            queued_count = 0
+            failed_count = 0
+
+            # Loop through the slots in the queue and count based on status
+            for slot in sabqueue:
+                status = slot.get('status', '')  # Safe check for missing 'status' key
+                if status == 'Downloading':
+                    downloading_count += 1
+                elif status == 'Queued':
+                    queued_count += 1
+                elif status == 'Failed':
+                    failed_count += 1
+
+            # Prepare the response structure
+            response = {
+                "downloading": downloading_count,
+                "queued": queued_count,
+                "failed": failed_count,
+            }
+
+            return jsonify(response)
+
+        return jsonify({"error": "Access Denied"}), 403        
     
 download_thread = threading.Thread(target=run_download_queue)
 download_thread.daemon = True  # Ensures the thread stops when the program ends
 download_thread.start()
 
 if __name__ == "__main__":
-    # load configs and plugins
+    # load config and plugins
     start()
-    # start flask
-    app.run(host=FLASK_HOST, port=FLASK_PORT)
+    threading.Thread(target=run_download_queue, daemon=True).start()
+    app.run(host=FLASK_HOST, port=int(FLASK_PORT))

--- a/config/config.json
+++ b/config/config.json
@@ -1,5 +1,5 @@
 {
-  "download_directory": "/data/downloads/downloadarr",
+  "download_directory": "/data/usenet/complete",
   "sab_api": "abcde",
-  "sab_categories": ["readarr", "lidarr", "sonarr", "lidarr_audiobook"]
+  "sab_categories": ["books", "music", "audiobooks"]
 }

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,17 +1,16 @@
-version: '3.8'
-
 services:
-  newznabarr:
-    image: riffsphereha/newznabarr:latest
-    container_name: newznabarr
-    environment:
-      - FLASK_RUN_PORT=10000
-      - PUID=1000
-      - PGID=1000
-      - CONFIG=/config
-    ports:
-      - "10000:10000"
-    volumes:
-      - /path/to/config:/config
-      - /path/to/download:/data/downloads/downloadarr
-    restart: unless-stopped
+    newznabarr:
+        image: riffsphereha/newznabarr
+        container_name: newznabarr          
+        environment:
+            - FLASK_RUN_PORT=10000        
+            - PUID=1000
+            - PGID=1000
+        volumes:
+            - /path/to/config:/config:/config              
+            - /path/to/data/usenet:/data/usenet
+        ports:
+            - 10000:10000
+        restart: unless-stopped  
+        networks:
+            - docker_network

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,7 +7,7 @@ services:
             - PUID=1000
             - PGID=1000
         volumes:
-            - /path/to/config:/config:/config              
+            - /path/to/config:/config              
             - /path/to/data/usenet:/data/usenet
         ports:
             - 10000:10000

--- a/newznabarr.subdomain.conf.sample
+++ b/newznabarr.subdomain.conf.sample
@@ -1,0 +1,37 @@
+server {
+    listen 443 ssl;
+    server_name newznabarr.*;
+
+    include /config/nginx/ssl.conf;
+    
+    # enable for ldap auth (requires ldap-location.conf in the location block)
+    #include /config/nginx/ldap-server.conf;
+
+    # enable for Authelia (requires authelia-location.conf in the location block)
+    #include /config/nginx/authelia-server.conf;
+
+    # enable for Authentik (requires authentik-location.conf in the location block)
+    #include /config/nginx/authentik-server.conf;
+
+    client_max_body_size 0;
+
+    location / {
+        # enable the next two lines for http auth
+        #auth_basic "Restricted";
+        #auth_basic_user_file /config/nginx/.htpasswd;
+
+        # enable for ldap auth (requires ldap-server.conf in the server block)
+        #include /config/nginx/ldap-location.conf;
+
+        # enable for Authelia (requires authelia-server.conf in the server block)
+        #include /config/nginx/authelia-location.conf;
+
+        # enable for Authentik (requires authentik-server.conf in the server block)
+        #include /config/nginx/authentik-location.conf;
+
+        proxy_pass http://newznabarr:10000;  # Docker internal address if on the same docker network. Or use your IP and port
+        include /config/nginx/proxy.conf;
+
+    }
+    
+}

--- a/newznabarr.subfolder.conf.sample
+++ b/newznabarr.subfolder.conf.sample
@@ -1,0 +1,25 @@
+## Version 2023/02/05
+# make sure that your newznabarr container is named newznabarr
+
+location ^~ /queue {
+    # enable the next two lines for http auth
+    #auth_basic "Restricted";
+    #auth_basic_user_file /config/nginx/.htpasswd;
+
+    # enable for ldap auth (requires ldap-server.conf in the server block)
+    #include /config/nginx/ldap-location.conf;
+
+    # enable for Authelia (requires authelia-server.conf in the server block)
+    #include /config/nginx/authelia-location.conf;
+
+    # enable for Authentik (requires authentik-server.conf in the server block)
+    #include /config/nginx/authentik-location.conf;
+
+    include /config/nginx/proxy.conf;
+    include /config/nginx/resolver.conf;
+    set $upstream_app newznabarr;
+    set $upstream_port 10000;
+    set $upstream_proto http;
+    proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+
+}

--- a/readme.md
+++ b/readme.md
@@ -47,7 +47,7 @@ Let me know what you think, and if you have any ideas for additional plugins, a 
   - For Unraid, set `PUID` to `99` and `PGID` to `100`.
 - **Download Folder**:
   - Add a download folder that matches your setup and update the `config.json` file to reflect this folder.
-  - **Note**: The default path is still using the old name `/data/downloads/downloadarr` (this will be updated in future versions).
+  - **Note**: The default path is based on Trash guides folder structure `/data/usenet/complete`.
 
 ---
 
@@ -84,4 +84,9 @@ Let me know what you think, and if you have any ideas for additional plugins, a 
 ## Additional Information
 
 - For more advanced configurations, or if you need to modify the default behavior, check the `config.json` file.
+- (get)Homepage Widget for services.yaml available -- see txt file.
+- SWAG Reverse Proxy example confs available -- see sample files.
 - Stay tuned for upcoming features, including more plugin support and enhancements!
+
+
+


### PR DESCRIPTION
- Changes to API variable in order to capture config API at start().
- Created new API endpoint /api?mode=widget for (get)Homepage.
- Changed download dir and sab_categories to match Trash Guides.
- Added log warnings to change the API from the default.
- Minor code fixes
- Added additional txt files for reverse proxy examples.
- Updated docker-compose.yaml example.
- Updated ReadMe.
- Updated default config to match Trash Guides.

![image](https://github.com/user-attachments/assets/20001a3d-fbe8-47fd-8cfa-1f4f88bbc8d3)
Screenshot of Homepage Widget
